### PR TITLE
Explicitly configure listen addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,10 @@ e.g. `KUBE-SERVICES`.
 To reach services from your host, you can do:
 
 ```
+# On Linux
 sudo route add -net 10.32.0.0/24 gw 192.168.222.10
+# On macOS
+sudo route -n add -net 10.32.0.0/24 192.168.222.10
 ```
 
 #### kubelet
@@ -306,6 +309,11 @@ Test the setup by creating a Nginx deployment, expose it and send a request
 to the service IP:
 
 ```
+# On Linux
 sudo route add -net 10.32.0.0/24 gw 192.168.222.10
+# On macOS
+sudo route -n add -net 10.32.0.0/24 192.168.222.10
+
+# Run the smoke test
 ./scripts/smoke-test
 ```

--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ members are alive, the service will start. We take advantage of that to make
 sure all three etcd member nodes start with the same "initial cluster" setting
 (and therefore have the same cluster ID to be able to form a cluster).
 
+For each node and service instance, we have to add an etcd environment config
+file with service instance specific configuration, as that's not supported
+by Habitat (as far as I know).
+
+```
+# On each node, replace X with node number (i.e. '0' for node-0 and so on)
+cat >/var/lib/etcd-env-vars <<ETCD_ENV_VARS
+export ETCD_LISTEN_CLIENT_URLS="https://192.168.222.1X:2379"
+export ETCD_LISTEN_PEER_URLS="https://192.168.222.1X:2380"
+export ETCD_ADVERTISE_CLIENT_URLS="https://192.168.222.1X:2379"
+export ETCD_INITIAL_ADVERTISE_PEER_URLS="https://192.168.222.1X:2380"
+ETCD_ENV_VARS
+```
+
 Now we have to update the etcd.default service group configuration to make etcd
 use our SSL certifcates (this has only to be done once for a service group; we
 use node-0 here):

--- a/config/svc-etcd.toml
+++ b/config/svc-etcd.toml
@@ -1,6 +1,9 @@
 etcd-auto-tls = "false"
 etcd-http-proto = "https"
 
+etcd-listen-host-ip = "0.0.0.0"
+etcd-initial-cluster = "node-0=https://192.168.222.10:2380,node-1=https://192.168.222.11:2380,node-2=https://192.168.222.12:2380"
+
 etcd-client-cert-auth = "true"
 etcd-cert-file = "files/etcd.pem"
 etcd-key-file = "files/etcd-key.pem"
@@ -10,3 +13,5 @@ etcd-peer-client-cert-auth = "true"
 etcd-peer-cert-file = "files/etcd.pem"
 etcd-peer-key-file = "files/etcd-key.pem"
 etcd-peer-trusted-ca-file = "files/ca.pem"
+
+etcd-env-vars-file = "/var/lib/etcd-env-vars"

--- a/config/svc-kubernetes-apiserver.toml
+++ b/config/svc-kubernetes-apiserver.toml
@@ -1,3 +1,5 @@
+advertise-address = "192.168.222.10"
+
 client-ca-file = "files/ca.pem"
 
 etcd-cafile = "files/ca.pem"

--- a/scripts/generate-kubeconfig
+++ b/scripts/generate-kubeconfig
@@ -4,7 +4,7 @@ set -euo pipefail
 
 readonly dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-find "${dir}/../config/" -iname '*.kubeconfig' -print0 | xargs -0 -r rm -v
+find "${dir}/../config/" -iname '*.kubeconfig' -print0 | xargs -0 rm -vf
 
 for i in {0..5}; do
   node_kubeconfig="${dir}/../config/node-${i}/kubeconfig"

--- a/scripts/generate-ssl-certificates
+++ b/scripts/generate-ssl-certificates
@@ -7,7 +7,7 @@ readonly dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 pushd "${dir}/../certificates" >/dev/null
 trap 'popd >/dev/null' EXIT
 
-find . \( -iname '*.csr' -o -iname '*.pem' \) -print0 | xargs -0 -r rm -v
+find . \( -iname '*.csr' -o -iname '*.pem' \) -print0 | xargs -0 rm -vf
 
 # ca
 cfssl gencert -initca ca-csr.json | cfssljson -bare ca

--- a/scripts/setup
+++ b/scripts/setup
@@ -19,6 +19,17 @@ vagrant ssh node-0 -- sudo hab sup start schu/etcd --topology leader
 vagrant ssh node-1 -- sudo hab sup start schu/etcd --topology leader --peer 192.168.222.10
 vagrant ssh node-2 -- sudo hab sup start schu/etcd --topology leader --peer 192.168.222.10
 
+for i in {0..2}; do
+  cat <<EOF | vagrant ssh node-${i} -- sudo bash
+cat >/var/lib/etcd-env-vars <<ETCD_ENV_VARS
+export ETCD_LISTEN_CLIENT_URLS="https://192.168.222.1${i}:2379"
+export ETCD_LISTEN_PEER_URLS="https://192.168.222.1${i}:2380"
+export ETCD_ADVERTISE_CLIENT_URLS="https://192.168.222.1${i}:2379"
+export ETCD_INITIAL_ADVERTISE_PEER_URLS="https://192.168.222.1${i}:2380"
+ETCD_ENV_VARS
+EOF
+done
+
 cat <<'EOF' | vagrant ssh node-0 -- bash
 for f in /vagrant/certificates/{etcd.pem,etcd-key.pem,ca.pem}; do sudo hab file upload etcd.default 1 "${f}"; done
 EOF

--- a/scripts/smoke-test
+++ b/scripts/smoke-test
@@ -14,7 +14,7 @@ kubectl expose deploy nginx --port 8080 --target-port 80 --type=NodePort
 readonly service_ip="$(kubectl get services -o jsonpath='{.items[?(@.metadata.name=="nginx")].spec.clusterIP}')"
 readonly service_port="$(kubectl get services -o jsonpath='{.items[?(@.metadata.name=="nginx")].spec.ports[0].port}')"
 
-until curl -s --max-time 2 "http://${service_ip}:${service_port}"; do echo "waiting for service to come up"; sleep 1; done
+until curl -s --max-time 2 "http://${service_ip}:${service_port}"; do echo "waiting for nginx service to come up"; sleep 1; done
 
 kubectl delete svc nginx
 kubectl delete -f manifests/nginx.yaml

--- a/scripts/vagrant/setup-routes.bash
+++ b/scripts/vagrant/setup-routes.bash
@@ -2,9 +2,6 @@
 
 set -euo pipefail
 
-route add default gw 192.168.222.1
-eval "$(route -n | awk '{ if ($8 =="enp0s3" && $2 != "0.0.0.0") print "route del default gw " $2; }')"
-
 case "$(hostname)" in
   node-0)
     route add -net 10.21.0.0/16 gw 192.168.222.11


### PR DESCRIPTION
So far, we have been using the default's interface address implicitly in
a few places. That's not always working as intended, for example in a
Vagrant environment. Instead, explicitly configure listen addresses for
etcd and kube-apiserver.

Fix #3