### PR TITLE
Make node names resolvable for k8s components

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,16 @@ node-1    Ready     <none>    23m       v1.8.2
 node-2    Ready     <none>    23m       v1.8.2
 ```
 
+### Make node names resolvable for k8s components
+```
+# On each node
+cat >>/etc/hosts <<DNS_IPS
+192.168.222.10 node-0
+192.168.222.11 node-1
+192.168.222.12 node-2
+DNS_IPS
+```
+
 ## Smoke test
 
 Test the setup by creating a Nginx deployment, expose it and send a request

--- a/scripts/setup
+++ b/scripts/setup
@@ -158,3 +158,14 @@ sudo hab sup start core/kubernetes-kubelet --channel "${channel}"
 sudo hab config apply kubernetes-kubelet.default 1 /vagrant/config/svc-kubelet.toml # noop on repeated calls
 EOF
 done
+
+# Make node names resolvable for k8s components
+for i in {0..2}; do
+  cat <<EOF | vagrant ssh node-${i} -- sudo bash
+cat >>/etc/hosts <<DNS_IPS
+192.168.222.10 node-0
+192.168.222.11 node-1
+192.168.222.12 node-2
+DNS_IPS
+EOF
+done


### PR DESCRIPTION
This PR fixes `server misbehaving` problem when trying to exec into a pod or check logs at least.
It makes the node names resolvable for k8s components by adding the node names and IPs to /etc/hosts file.



