### PR TITLE
list-peers: Update command to work with hab 0.61

### DIFF
--- a/scripts/list-peers
+++ b/scripts/list-peers
@@ -5,4 +5,4 @@ set -euo pipefail
 readonly peer="${1:-192.168.222.10}"
 
 curl -sS "http://${peer}:9631/butterfly" | \
-  jq -r '.member.members[].proto.address'
+  jq -r '.member.members[].address'


### PR DESCRIPTION
The API response of 0.61 has changed where it does not have the
address as part of the `proto` key. Instead it got bumped up directly
under the parent of the `proto` key.