### PR TITLE
smoke-test: Fix bad nginx image reference

### DIFF
--- a/manifests/nginx.yaml
+++ b/manifests/nginx.yaml
@@ -11,6 +11,6 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx
+        image: nginx:stable
         ports:
         - containerPort: 80


### PR DESCRIPTION
There is a wider issue because of the `nginx:latest` has stopped
working. Using `nginx:stable` continues to work as a stop gap measure.

Link to issue: https://github.com/nginxinc/docker-nginx/issues/262